### PR TITLE
Fix: make some functionality public to enable API extension

### DIFF
--- a/HarvestKit-Shared/AccountController.swift
+++ b/HarvestKit-Shared/AccountController.swift
@@ -24,8 +24,8 @@ public final class AccountController {
     /**
      The request controller used to load account information. This is shared with other controllers
      */
-    let requestController: TSCRequestController
-    
+    public let requestController: TSCRequestController
+
     internal init(requestController: TSCRequestController) {
         
         self.requestController = requestController

--- a/HarvestKit-Shared/ClientsController.swift
+++ b/HarvestKit-Shared/ClientsController.swift
@@ -23,8 +23,8 @@ public final class ClientsController {
     /**
      The request controller used to load contact information. This is shared with other controllers
      */
-    let requestController: TSCRequestController
-    
+    public let requestController: TSCRequestController
+
     /**
      Initialises a new controller.
      - parameter requestController: The request controller to use when loading client information. This must be passed down from HarvestController so that authentication may be shared

--- a/HarvestKit-Shared/ContactsController.swift
+++ b/HarvestKit-Shared/ContactsController.swift
@@ -24,8 +24,8 @@ public final class ContactsController {
     /**
     The request controller used to load contact information. This is shared with other controllers
     */
-    let requestController: TSCRequestController
-    
+    public let requestController: TSCRequestController
+
     /**
     Initialises a new controller.
     - parameter requestController: The request controller to use when loading contact information. This must be passed down from HarvestController so that authentication may be shared

--- a/HarvestKit-Shared/HarvestController.swift
+++ b/HarvestKit-Shared/HarvestController.swift
@@ -25,8 +25,8 @@ public final class HarvestController {
     /**
      The main request controller for the harvest framework. This will be shared amongst other sub controllers for making API requests.
      */
-    let requestController: TSCRequestController
-    
+    public let requestController: TSCRequestController
+
     /**
      The controller for managing Timers
      */

--- a/HarvestKit-Shared/Timer.swift
+++ b/HarvestKit-Shared/Timer.swift
@@ -68,9 +68,9 @@ public struct Timer {
     Standard initialiser
     */
     public init() {}
-    
-    internal init?(dictionary: [String: AnyObject]) {
-        
+
+    public init?(dictionary: [String: AnyObject]) {
+
         identifier = dictionary["id"] as? Int
         notes = dictionary["notes"] as? String
         clientName = dictionary["client"] as? String

--- a/HarvestKit-Shared/TimersController.swift
+++ b/HarvestKit-Shared/TimersController.swift
@@ -24,8 +24,8 @@ public final class TimersController {
     /**
      The request controller used to load timer information. This is shared with other controllers
      */
-    let requestController: TSCRequestController
-    
+    public let requestController: TSCRequestController
+
     internal init(requestController: TSCRequestController) {
         
         self.requestController = requestController


### PR DESCRIPTION
The current API in the <X>Controller classes marks `.requestController` member internal. This prevents creating API extensions in the apps that use HarvestKit-Swift e.g

```
extension HarvestController {
 func yetAnotherGetFunction() // <- this needs to use requestController
} 
```

Same goes for the initializer of the Timer class. If it is marked as internal there is no way to extend TimersController in the client app with functions that would require to create Timer objects.
